### PR TITLE
[homebrew] Add brew formula for the 0.1.0-alpha pre-release of the jetpack cli

### DIFF
--- a/Formula/jetpack.rb
+++ b/Formula/jetpack.rb
@@ -1,4 +1,4 @@
-class Foo < Formula
+class Jetpack < Formula
   desc "Jetpack"
   homepage "https://www.jetpack.io"
 

--- a/Formula/jetpack.rb
+++ b/Formula/jetpack.rb
@@ -13,6 +13,18 @@ class Foo < Formula
     bin.install "jetpack"
   end
 
+  def caveats
+    <<~EOS
+      Thanks for installing the command-line tool for jetpack.io
+      Jetpack is currently available by invitation only. Before running, you
+      will have to set the JETPACK_TOKEN environment variable to a valid access
+      token. You might want to add that to your .bashrc (or equivalent):
+        export JETPACK_TOKEN=value-provided-by-jetpack-team
+      Once you've set the environment variable, you should be able to run:
+        jetpack
+    EOS
+  end
+
   test do
     system "#{bin}/jetpack version"
   end

--- a/Formula/jetpack.rb
+++ b/Formula/jetpack.rb
@@ -4,7 +4,7 @@ class Foo < Formula
 
   url "https://releases.jetpack.io/jetpack/0.1.0/jetpack_0.1.0-alpha_darwin_amd64.zip"
 
-  sha256 "0a2358a0cbf1965101b73404a7a93ff8a2da084dec6f64d5e74f64aa2ce51754"
+  sha256 "6578bd69ea4f2c37e0ef8a82d111a70806a221de4c40853ce5e1b42220195100"
   # Version numbers should follow the semantic versioning spec
   version "0.1.0-alpha"
   bottle :unneeded

--- a/Formula/jetpack.rb
+++ b/Formula/jetpack.rb
@@ -2,13 +2,11 @@ class Foo < Formula
   desc "Jetpack"
   homepage "https://www.jetpack.io"
 
-  # For now download releases directly from GitHub, but eventually we should host
-  # them at releases.jetpack.io:
-  # url "https://releases.jetpack.io/jetpack/v0.1.0/jetpack_0.1.0_darwin_amd64.zip"
-  url "https://github.com/jetpack-io/jetpack/releases/download/v0.1.0/jetpack_0.1.0_darwin_amd64.zip"
+  url "https://releases.jetpack.io/jetpack/0.1.0/jetpack_0.1.0-alpha_darwin_amd64.zip"
 
-  sha256 "85cc828a96735bdafcf29eb6291ca91bac846579bcef7308536e0c875d6c81d7"
-  version "0.1.0"
+  sha256 "0a2358a0cbf1965101b73404a7a93ff8a2da084dec6f64d5e74f64aa2ce51754"
+  # Version numbers should follow the semantic versioning spec
+  version "0.1.0-alpha"
   bottle :unneeded
 
   def install

--- a/Formula/jetpack.rb
+++ b/Formula/jetpack.rb
@@ -1,0 +1,21 @@
+class Foo < Formula
+  desc "Jetpack"
+  homepage "https://www.jetpack.io"
+
+  # For now download releases directly from GitHub, but eventually we should host
+  # them at releases.jetpack.io:
+  # url "https://releases.jetpack.io/jetpack/v0.1.0/jetpack_0.1.0_darwin_amd64.zip"
+  url "https://github.com/jetpack-io/jetpack/releases/download/v0.1.0/jetpack_0.1.0_darwin_amd64.zip"
+
+  sha256 "85cc828a96735bdafcf29eb6291ca91bac846579bcef7308536e0c875d6c81d7"
+  version "0.1.0"
+  bottle :unneeded
+
+  def install
+    bin.install "jetpack"
+  end
+
+  test do
+    system "#{bin}/jetpack version"
+  end
+end


### PR DESCRIPTION
Add brew formula for the 0.1.0-alpha pre-release of the jetpack cli

Remember this PR is part of a public repo.